### PR TITLE
Correct usage of launcher parameter `OverwritePublicIP`

### DIFF
--- a/AstroLauncher.py
+++ b/AstroLauncher.py
@@ -63,7 +63,7 @@ class AstroLauncher():
         AutoRestartEveryHours: float = 24
         AutoRestartSyncTimestamp: str = "00:00"
         DisableNetworkCheck: bool = False
-        OverwritePublicIP: bool = False
+        OverwritePublicIP: bool = True
         ShowServerFPSInConsole: bool = True
         AdminAutoConfigureFirewall: bool = True
         LogRetentionDays: int = 7

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ AutoRestartEveryHours = 24
 DisableNetworkCheck = False
 
 # Always Overwrite the PublicIP setting in AstroServerSettings.ini
-OverwritePublicIP = False
+OverwritePublicIP = True
 
 # Enable/Disable showing server FPS in console. This will probably spam your console when playing are in your server
 ShowServerFPSInConsole = True

--- a/cogs/AstroDedicatedServer.py
+++ b/cogs/AstroDedicatedServer.py
@@ -103,7 +103,7 @@ class AstroDedicatedServer():
         self.DSListGames = ""
         self.busy = False
         self.getPaks()
-        self.refresh_settings(ovrIP=True)
+        self.refresh_settings(ovrIP=launcher.launcherConfig.OverwritePublicIP)
         self.AstroRCON = None
 
     def start_RCON(self):


### PR DESCRIPTION
My Astroneer dedicated server is behind a CGNAT (IPv6) (my pc 😄).
I'm experimenting the usage of a VPS (IPv4) and proxifying the UDP connexion through zerotier.

I made small fixes to allow me to disable the overwrite of publicIp. The default behavior is still to overwrite the public IP.

### Changes

- Replace static `True` by the real parameter `launcher.launcherConfig.OverwritePublicIP`
- Change the default value of OverwritePublicIP from `False` to `True`